### PR TITLE
fix: add multi character ascii keys

### DIFF
--- a/ch9329/keyboard.py
+++ b/ch9329/keyboard.py
@@ -80,10 +80,10 @@ def send(ser: Serial, key: str = "", modifier: str = "") -> None:
 
     if key:
         # ascii keys
-        if len(key) == 1:
+        try:
             shift, keycode = get_ascii_keycode(key)
         # Non ascii keys
-        else:
+        except:
             shift, keycode = get_non_ascii_keycode(key)
         if shift:
             data += HID_KEY_SHIFT_LEFT


### PR DESCRIPTION
Backspace: '\b'.
Tab: '\t'
Enter: '\r'
Delete: '\x7f'
Escape (ESC): '\x1b'