### PR TITLE
Actually raise a TooManyKeysError for more than 6 keys in trigger_keys

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,0 +1,29 @@
+name: Python package
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'  # You can specify a specific Python version if needed
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"  # Install the package and development dependencies
+
+      - name: Run tests
+        run: |
+          pytest

--- a/ch9329/keyboard.py
+++ b/ch9329/keyboard.py
@@ -126,7 +126,6 @@ def trigger_keys(
     press_keys = list(set(press_keys))
     press_modifiers = list(set(press_modifiers))
     # Supports press to 6 normal buttons at the same time
-    press_keys = press_keys[:6]
     if len(press_keys) > 6:
         raise TooManyKeysError(
             "CH9329 supports maximum of 6 keys to be pressed at once."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,9 @@ Issues = "https://github.com/sandbox-pokhara/ch9329/issues"
 [project.scripts]
 lsch9329 = "ch9329.tools.lsch9329:main"
 
+[project.optional-dependencies]
+dev = ["pytest"]
+
 [tool.setuptools]
 include-package-data = true
 

--- a/tests/test_keyboard.py
+++ b/tests/test_keyboard.py
@@ -1,0 +1,9 @@
+import pytest
+from unittest.mock import Mock
+from ch9329.keyboard import *
+
+
+def test_trigger_keys_raises_for_too_many_keys():
+    with pytest.raises(TooManyKeysError):
+        ser = Mock()
+        trigger_keys(ser, ["a", "b", "c", "d", "e", "f", "g"])


### PR DESCRIPTION
The hardware only supports up to six keys at a time, and this function should raise an exception when more keys are passed. However, the press_keys list was first reduced to six items and then checked, meaning it would never raise an exception and still silently ignored keys. Also added a unit test to verify this behavior.
    
Related to #12.
