### PR TITLE
feat: change the mouse press() and click() function

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,17 @@ keyboard.write(ser, "!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~\n")
 mouse.move(ser, x=500, y=500)
 mouse.move(ser, x=50, y=50, relative=True)
 mouse.click(ser, button="left")
+# On some devices
+# Maybe you need to enter full coordinates for mouse clicks
+mouse.click(
+    ser,
+    button="left",
+    x=50,
+    y=50,
+    relative=False,
+    monitor_width=1920,
+    monitor_height=1080
+)
 
 print(get_serial_number(ser))
 # 20193152CFBF

--- a/ch9329/mouse.py
+++ b/ch9329/mouse.py
@@ -96,16 +96,35 @@ def move(
         send_data_absolute(ser, x, y, "null", monitor_width, monitor_height)
 
 
-def press(ser: Serial, button: str = "left") -> None:
-    send_data_absolute(ser, 0, 0, button)
+def press(
+    ser: Serial,
+    button: str = "left",
+    x: int = 0,
+    y: int = 0,
+    relative: bool = False,
+    monitor_width: int = 1920,
+    monitor_height: int = 1080
+) -> None:
+    if relative:
+        send_data_relative(ser, x, y, button)
+    else:
+        send_data_absolute(ser, x, y, button, monitor_width, monitor_height)
 
 
 def release(ser: Serial) -> None:
     send_data_absolute(ser, 0, 0, "null")
 
 
-def click(ser: Serial, button: str = "left") -> None:
-    press(ser, button)
+def click(
+    ser: Serial,
+    button: str = "left",
+    x: int = 0,
+    y: int = 0,
+    relative: bool = False,
+    monitor_width: int = 1920,
+    monitor_height: int = 1080
+) -> None:
+    press(ser, button, x, y, relative, monitor_width, monitor_height)
     # 100 to 450 milliseconds delay for simulating natural behavior
     time.sleep(random.uniform(0.1, 0.45))
     release(ser)


### PR DESCRIPTION
When I used CH9329, I noticed that on some DELL UEFI BIOS, the left mouse button doesn't trigger properly.

The phenomenon is: 
after pressing the left mouse button, the mouse moves to the upper left corner of the screen (x=0, y=0).


Finally, I read the datasheet and tested it and found that the mouse coordinates and click events are actually sent at the same time.
Some operating systems ignore coordinates on clicks, like Windows or ASUS BIOS, but Dell apparently doesn't.

I think a better solution would be to allow the user to enter a coordinate at the same time as the click event is sent, and to differentiate between relative and absolute coordinates (although I think the relative coordinate should still always be 0).
I'm sure this change wouldn't break compatibility. I have tested it in my project and it will work again in DELL BIOS with this change.