### PR TITLE
Raise exception when something fails

### DIFF
--- a/ch9329/exceptions.py
+++ b/ch9329/exceptions.py
@@ -8,3 +8,7 @@ class InvalidKey(Exception):
 
 class TooManyKeysError(Exception):
     pass
+
+
+class ProtocolError(Exception):
+    pass

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,11 @@
+import pytest
+from unittest.mock import Mock
+from ch9329.config import *
+
+
+def test_set_device_descriptors_raises_for_too_long_descriptor():
+    with pytest.raises(ValueError):
+        ser = Mock()
+        set_device_descriptors(
+            ser, USBStringDescriptor.MANUFACTURER, "long" * 50
+        )


### PR DESCRIPTION
When the hardware sends an unexpected response, raise an exception.

Especially for get_parameters it didn't make sense to return an empty string, since this normally returns a bytes-like object. Exceptions are meant for this and make it easier to handle errors without the need of checking return values. Also, it makes it possible to distinguish between an error and sucessfully retrieving an empty string.