### PR TITLE
feat: add configuration class

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ from serial import Serial
 from ch9329 import keyboard
 from ch9329 import mouse
 from ch9329.config import get_manufacturer
+from ch9329.config import get_parameters
 from ch9329.config import get_product
 from ch9329.config import get_serial_number
 
@@ -40,6 +41,34 @@ print(get_product(ser))
 # WCH UART TO KB-MS_V1.7
 print(get_manufacturer(ser))
 # WWW.WCH.CN
+
+params = get_parameters(ser)
+print(f"cmd: {params.cmd}")
+print(f"chip_working_mode: {params.chip_working_mode}")
+print(f"serial_comm_mode: {params.serial_comm_mode}")
+print(f"serial_comm_address: {params.serial_comm_address}")
+print(f"serial_comm_baud_rate: {params.serial_comm_baud_rate}")
+print(f"serial_comm_packet_interval: {params.serial_comm_packet_interval}")
+print(f"usb_vid: {params.usb_vid}")
+print(f"usb_pid: {params.usb_pid}")
+print(f"usb_keyboard_upload_interval: {params.usb_keyboard_upload_interval}")
+print(f"usb_keyboard_release_delay: {params.usb_keyboard_release_delay}")
+print(f"usb_keyboard_automatic_return: {params.usb_keyboard_automatic_return}")
+print(f"usb_string_enable: {params.usb_string_enable}")
+print(f"usb_fast_upload: {params.usb_fast_upload}")
+# cmd: 136
+# chip_working_mode: 128
+# serial_comm_mode: 128
+# serial_comm_address: 0
+# serial_comm_baud_rate: 9600
+# serial_comm_packet_interval: 3
+# usb_vid: 6790
+# usb_pid: 57641
+# usb_keyboard_upload_interval: 0
+# usb_keyboard_release_delay: 1
+# usb_keyboard_automatic_return: 0
+# usb_string_enable: 0
+# usb_fast_upload: 0
 
 ser.close()
 ```

--- a/ch9329/config.py
+++ b/ch9329/config.py
@@ -1,10 +1,11 @@
+import struct
 from enum import Enum
+from typing import Any
 
 from serial import Serial
 
 from ch9329.exceptions import ProtocolError
 from ch9329.utils import get_packet
-import struct
 
 HEAD = b"\x57\xab"  # Frame header
 ADDR = b"\x00"  # Address
@@ -32,11 +33,12 @@ CMD_SET_USB_STRING = b"\x0b"
 
 
 class Configuration(bytearray):
-    def _create_property(fmt, offset):
-        def getter(self):
+    @staticmethod
+    def _create_property(fmt: str, offset: int) -> Any:
+        def getter(self: "Configuration") -> Any:
             return struct.unpack_from(fmt, self, offset)[0]
 
-        def setter(self, value):
+        def setter(self: "Configuration", value: Any) -> None:
             struct.pack_into(fmt, self, offset, value)
 
         return property(getter, setter)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,7 @@
-import pytest
 from unittest.mock import Mock
+
+import pytest
+
 from ch9329.config import *
 
 
@@ -12,7 +14,9 @@ def test_set_device_descriptors_raises_for_too_long_descriptor():
 
 
 def test_get_parameters_returns_bytes_like_object():
-    serial_response = bytes.fromhex("57ab0088328080000000258008000003861a29e100000001000d000000000000000000000000000000000000000000000000000000000024")
+    serial_response = bytes.fromhex(
+        "57ab0088328080000000258008000003861a29e100000001000d000000000000000000000000000000000000000000000000000000000024"
+    )
     ser = Mock()
     ser.readall.return_value = serial_response
     response = get_parameters(ser)
@@ -21,7 +25,9 @@ def test_get_parameters_returns_bytes_like_object():
 
 
 def test_get_set_field_on_configuration():
-    serial_response = bytes.fromhex("57ab0088328080000000258008000003861a29e100000001000d000000000000000000000000000000000000000000000000000000000024")
+    serial_response = bytes.fromhex(
+        "57ab0088328080000000258008000003861a29e100000001000d000000000000000000000000000000000000000000000000000000000024"
+    )
     #                                HEAD  CMD WM  CA        RSVD    VID     UTI     AE                                SE  RESERVED5566778899101112
     #                                    ADR LEN CM  BAUD        PINT    PID     RDT   CR CH1  CR CH2  FLT ST  FLT END   FU                        CS
 
@@ -31,8 +37,8 @@ def test_get_set_field_on_configuration():
     assert config.serial_comm_address == 0x00
     assert config.serial_comm_baud_rate == 9600
     assert config.serial_comm_packet_interval == 3
-    assert config.usb_vid == 0x1a86
-    assert config.usb_pid == 0xe129
+    assert config.usb_vid == 0x1A86
+    assert config.usb_pid == 0xE129
     assert config.usb_keyboard_upload_interval == 0
     assert config.usb_keyboard_release_delay == 1
 
@@ -42,14 +48,17 @@ def test_get_set_field_on_configuration():
     config.serial_comm_baud_rate = 0x4455
     config.serial_comm_packet_interval = 0x6677
     config.usb_vid = 0x8899
-    config.usb_pid = 0xaabb
-    config.usb_keyboard_upload_interval = 0xccdd
-    config.usb_keyboard_release_delay = 0xeeff
+    config.usb_pid = 0xAABB
+    config.usb_keyboard_upload_interval = 0xCCDD
+    config.usb_keyboard_release_delay = 0xEEFF
     config.usb_keyboard_automatic_return = 1
     config.usb_string_enable = 2
     config.usb_fast_upload = 3
 
-    assert config.hex() == "57ab00883201020300004455080066779988bbaaccddeeff010d000000000000000000000000000000020300000000000000000000000024"
+    assert (
+        config.hex()
+        == "57ab00883201020300004455080066779988bbaaccddeeff010d000000000000000000000000000000020300000000000000000000000024"
+    )
     #                        0 1 2 3 4 5 6 7 8 910111213141516171819202122232425262728293031323334353637383940414243444546474849505152535455
     #                       HEAD  CMD WM  CA        RSVD    VID     UTI     AE                                SE  RESERVED5566778899101112
     #                           ADR LEN CM  BAUD        PINT    PID     RDT   CR CH1  CR CH2  FLT ST  FLT END   FU                        CS

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -9,3 +9,47 @@ def test_set_device_descriptors_raises_for_too_long_descriptor():
         set_device_descriptors(
             ser, USBStringDescriptor.MANUFACTURER, "long" * 50
         )
+
+
+def test_get_parameters_returns_bytes_like_object():
+    serial_response = bytes.fromhex("57ab0088328080000000258008000003861a29e100000001000d000000000000000000000000000000000000000000000000000000000024")
+    ser = Mock()
+    ser.readall.return_value = serial_response
+    response = get_parameters(ser)
+    assert response[0] == 0x57
+    assert response.hex() == serial_response.hex()
+
+
+def test_get_set_field_on_configuration():
+    serial_response = bytes.fromhex("57ab0088328080000000258008000003861a29e100000001000d000000000000000000000000000000000000000000000000000000000024")
+    #                                HEAD  CMD WM  CA        RSVD    VID     UTI     AE                                SE  RESERVED5566778899101112
+    #                                    ADR LEN CM  BAUD        PINT    PID     RDT   CR CH1  CR CH2  FLT ST  FLT END   FU                        CS
+
+    config = Configuration(serial_response)
+    assert config.chip_working_mode == 0x80
+    assert config.serial_comm_mode == 0x80
+    assert config.serial_comm_address == 0x00
+    assert config.serial_comm_baud_rate == 9600
+    assert config.serial_comm_packet_interval == 3
+    assert config.usb_vid == 0x1a86
+    assert config.usb_pid == 0xe129
+    assert config.usb_keyboard_upload_interval == 0
+    assert config.usb_keyboard_release_delay == 1
+
+    config.chip_working_mode = 1
+    config.serial_comm_mode = 2
+    config.serial_comm_address = 3
+    config.serial_comm_baud_rate = 0x4455
+    config.serial_comm_packet_interval = 0x6677
+    config.usb_vid = 0x8899
+    config.usb_pid = 0xaabb
+    config.usb_keyboard_upload_interval = 0xccdd
+    config.usb_keyboard_release_delay = 0xeeff
+    config.usb_keyboard_automatic_return = 1
+    config.usb_string_enable = 2
+    config.usb_fast_upload = 3
+
+    assert config.hex() == "57ab00883201020300004455080066779988bbaaccddeeff010d000000000000000000000000000000020300000000000000000000000024"
+    #                        0 1 2 3 4 5 6 7 8 910111213141516171819202122232425262728293031323334353637383940414243444546474849505152535455
+    #                       HEAD  CMD WM  CA        RSVD    VID     UTI     AE                                SE  RESERVED5566778899101112
+    #                           ADR LEN CM  BAUD        PINT    PID     RDT   CR CH1  CR CH2  FLT ST  FLT END   FU                        CS

--- a/tests/test_keyboard.py
+++ b/tests/test_keyboard.py
@@ -1,5 +1,7 @@
-import pytest
 from unittest.mock import Mock
+
+import pytest
+
 from ch9329.keyboard import *
 
 


### PR DESCRIPTION
To make it easier to view and modify the various configuration fields. Configuration is a bytes-like object to remain backward compatible, but it has properties that do the packing and unpacking from the configuration byte string. This makes it easier to view and change the various configuration parameters.

The result of `get_parameters` now has more fields to easily access the configuration:

```
curconf = config.get_parameters(ser)
print(f"Current baud rate is {curconf.serial_comm_baud_rate}")
```

Currently this is missing the return characters configuration and the filter characters configuration. Also, it does not modify the checksum field automatically when changing the configuration fields. There is not a function yet to send a modified configuration back to the hardware.